### PR TITLE
fix: make fromSeed function public

### DIFF
--- a/.github/workflows/swift-test-and-build.yaml
+++ b/.github/workflows/swift-test-and-build.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Swift
-        uses: swift-actions/setup@v2
+        uses: swift-actions/setup-swift@v2
         with:
           swift-version: "5.9"
 

--- a/Sources/x-hd-wallet-api/x-hd-wallet-api.swift
+++ b/Sources/x-hd-wallet-api/x-hd-wallet-api.swift
@@ -121,7 +121,7 @@ public class XHDWalletAPI {
         }
     }
 
-    func fromSeed(_ seed: Data) -> Data {
+    public func fromSeed(_ seed: Data) -> Data {
         // k = H512(seed)
         var k = CryptoUtils.sha512(data: seed)
         var kL = k.subdata(in: 0 ..< ED25519_SCALAR_SIZE)

--- a/Tests/x-hd-wallet-apiTests/x-hd-wallet-apiTests.swift
+++ b/Tests/x-hd-wallet-apiTests/x-hd-wallet-apiTests.swift
@@ -16,9 +16,9 @@
  */
 
 import BigInt
-@testable import x_hd_wallet_api
 import MessagePack
 import MnemonicSwift
+@testable import x_hd_wallet_api
 import XCTest
 
 enum MyError: Error {


### PR DESCRIPTION
Made the function public to be able to reach from the application itself while using the deriveKey functionality as described in the example usages.